### PR TITLE
Update fix submodule and modulefile gsi_acorn.intel.lua

### DIFF
--- a/modulefiles/gsi_acorn.intel.lua
+++ b/modulefiles/gsi_acorn.intel.lua
@@ -13,7 +13,6 @@ local netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
 local bufr_ver=os.getenv("bufr_ver") or "12.1.0"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 local w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
-local sp_ver=os.getenv("sp_ver") or "2.3.3"
 local ip_ver=os.getenv("ip_ver") or "5.1.0"
 local sigio_ver=os.getenv("sigio_ver") or "2.3.2"
 local sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
@@ -36,7 +35,6 @@ load(pathJoin("netcdf", netcdf_ver))
 load(pathJoin("bufr", bufr_ver))
 load(pathJoin("bacio", bacio_ver))
 load(pathJoin("w3emc", w3emc_ver))
-load(pathJoin("sp", sp_ver))
 --load(pathJoin("ip", ip_ver))
 -- Temporarily define IP's paths here.
 -- TODO when testing is complete, request an official installation in https://github.com/NOAA-EMC/WCOSS2-requests/issues/11

--- a/modulefiles/gsi_acorn.intel.lua
+++ b/modulefiles/gsi_acorn.intel.lua
@@ -3,7 +3,7 @@ help([[
 
 local PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.1.0"
 local intel_ver=os.getenv("intel_ver") or "19.1.3.304"
-local craype_ver=os.getenv("craype_ver") or "2.7.10"
+local craype_ver=os.getenv("craype_ver") or "2.7.8"
 local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.7"
 local cmake_ver= os.getenv("cmake_ver") or "3.20.2"
 local python_ver=os.getenv("python_ver") or "3.8.6"
@@ -12,17 +12,17 @@ local prod_util_ver=os.getenv("prod_util_ver") or "2.0.10"
 local netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
 local bufr_ver=os.getenv("bufr_ver") or "12.1.0"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
-local w3emc_ver=os.getenv("w3emc_ver") or "2.10.0"
-local ip_ver=os.getenv("ip_ver") or "5.2.0"
-local sigio_ver=os.getenv("sigio_ver") or "2.3.3"
-local sfcio_ver=os.getenv("sfcio_ver") or "1.4.2"
+local w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
+local sp_ver=os.getenv("sp_ver") or "2.3.3"
+local ip_ver=os.getenv("ip_ver") or "5.1.0"
+local sigio_ver=os.getenv("sigio_ver") or "2.3.2"
+local sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
 local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
 local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
 local crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.1"
 
-load(pathJoin("envvar", "1.0"))
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
 load(pathJoin("intel", intel_ver))
 load(pathJoin("craype", craype_ver))
@@ -36,12 +36,23 @@ load(pathJoin("netcdf", netcdf_ver))
 load(pathJoin("bufr", bufr_ver))
 load(pathJoin("bacio", bacio_ver))
 load(pathJoin("w3emc", w3emc_ver))
-load(pathJoin("ip", ip_ver))
+load(pathJoin("sp", sp_ver))
+--load(pathJoin("ip", ip_ver))
+-- Temporarily define IP's paths here.
+-- TODO when testing is complete, request an official installation in https://github.com/NOAA-EMC/WCOSS2-requests/issues/11
+pushenv("ip_ROOT", pathJoin("/lfs/h2/emc/nceplibs/noscrub/hpc-stack/libs/hpc-stack/intel-19.1.3.304/ip", ip_ver))
+pushenv("IP_INC4", pathJoin("/lfs/h2/emc/nceplibs/noscrub/hpc-stack/libs/hpc-stack/intel-19.1.3.304/ip", ip_ver, "include_4"))
+pushenv("IP_INCd", pathJoin("/lfs/h2/emc/nceplibs/noscrub/hpc-stack/libs/hpc-stack/intel-19.1.3.304/ip", ip_ver, "include_d"))
+pushenv("IP_LIB4", pathJoin("/lfs/h2/emc/nceplibs/noscrub/hpc-stack/libs/hpc-stack/intel-19.1.3.304/ip", ip_ver, "lib64/libip_4.a"))
+pushenv("IP_LIBd", pathJoin("/lfs/h2/emc/nceplibs/noscrub/hpc-stack/libs/hpc-stack/intel-19.1.3.304/ip", ip_ver, "lib64/libip_d.a"))
+pushenv("ip_VERSION", ip_ver)
+
 load(pathJoin("sigio", sigio_ver))
 load(pathJoin("sfcio", sfcio_ver))
 load(pathJoin("nemsio", nemsio_ver))
 load(pathJoin("wrf_io", wrf_io_ver))
 load(pathJoin("ncio", ncio_ver))
+--load(pathJoin("crtm", crtm_ver))
 load(pathJoin("ncdiag",ncdiag_ver))
 
 -- Lastly, load CRTM from the EMC location


### PR DESCRIPTION
**Description**
This PR brings two updates into `DavidHuber-GSI:feature/ss_191`
1. update `fix` submodule hash to be consistent with the authoritative `develop`
2. update `modulefiles/acorn.intel.lua` to be more consistent with `wcoss.intel.lua`

**Type of change**
- [ ] Maintenance

**How Has This Been Tested?**
Build `RussTreadon-NOAA:feature/ss_191` and authoritative `develop` on Acorn.  Run ctests with [results posted](https://github.com/NOAA-EMC/GSI/pull/890#issuecomment-2963668494) in GSI PR [#890](https://github.com/NOAA-EMC/GSI/pull/890).

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
